### PR TITLE
82-hotfix/filebox-preview-conflict-with-sidebar-menu

### DIFF
--- a/app/(protected)/filebox/_components/FilePreview.tsx
+++ b/app/(protected)/filebox/_components/FilePreview.tsx
@@ -116,7 +116,8 @@ export function FilePreview({
               </div>
             </ModalHeader>
 
-            <ModalBody className="flex items-center justify-center bg-gray-50 pt-12">
+            <ModalBody className="bg-gray-50 p-0">
+              <div className="w-full min-h-full p-6">
               {isPDF ? (
                 <div className="w-full">
                   {error && (
@@ -133,7 +134,7 @@ export function FilePreview({
                   )}
 
                   {!error && (
-                    <div className="flex flex-col items-center">
+                    <div className="flex flex-col items-center w-full">
                       <Document
                         file={previewUrl}
                         loading={
@@ -200,7 +201,7 @@ export function FilePreview({
                   {!error && (
                     <div
                       className="relative w-full max-w-3xl"
-                      style={{ height: "500px" }}
+                      style={{ height: "600px" }}
                     >
                       <Image
                         fill
@@ -271,6 +272,7 @@ export function FilePreview({
                   </div>
                 </div>
               )}
+              </div>
             </ModalBody>
 
             <ModalFooter className="gap-3">

--- a/app/(protected)/filebox/_components/FilePreview.tsx
+++ b/app/(protected)/filebox/_components/FilePreview.tsx
@@ -11,8 +11,9 @@ import {
   Spinner,
 } from "@heroui/react";
 import { Document, Page, pdfjs } from "react-pdf";
-import { ChevronLeft, ChevronRight, Download, X } from "lucide-react";
+import { ChevronLeft, ChevronRight, Download, X, ZoomIn, ZoomOut, Maximize2 } from "lucide-react";
 import Image from "next/image";
+import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
 import { FileItem } from "./FileItem";
 import { FileMetadata } from "@/types/filebox";
 import "react-pdf/dist/Page/AnnotationLayer.css";
@@ -191,7 +192,7 @@ export function FilePreview({
               ) : isImage ? (
                 <div
                   key={previewUrl}
-                  className="w-full flex flex-col items-center justify-center py-8"
+                  className="w-full flex flex-col items-center"
                 >
                   {loading && !error && (
                     <div className="flex items-center justify-center py-12">
@@ -199,22 +200,74 @@ export function FilePreview({
                     </div>
                   )}
                   {!error && (
-                    <div
-                      className="relative w-full max-w-3xl"
-                      style={{ height: "600px" }}
-                    >
-                      <Image
-                        fill
-                        unoptimized
-                        alt={file.name}
-                        className={`object-contain rounded-lg shadow-md transition-opacity duration-300 ${loading ? "opacity-0" : "opacity-100"}`}
-                        src={previewUrl}
-                        onError={() => {
-                          setLoading(false);
-                          setError("Failed to load image");
-                        }}
-                        onLoad={() => setLoading(false)}
-                      />
+                    <div className="w-full">
+                      <TransformWrapper
+                        initialScale={1}
+                        minScale={0.5}
+                        maxScale={4}
+                        centerOnInit={true}
+                        wheel={{ step: 0.1 }}
+                        doubleClick={{ mode: "reset" }}
+                      >
+                        {({ zoomIn, zoomOut, resetTransform }) => (
+                          <>
+                            {/* Zoom Controls */}
+                            <div className="flex items-center justify-center gap-2 mb-4">
+                              <Button
+                                isIconOnly
+                                size="sm"
+                                className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50"
+                                onPress={() => zoomOut()}
+                              >
+                                <ZoomOut className="w-4 h-4" />
+                              </Button>
+                              <Button
+                                isIconOnly
+                                size="sm"
+                                className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50"
+                                onPress={() => resetTransform()}
+                              >
+                                <Maximize2 className="w-4 h-4" />
+                              </Button>
+                              <Button
+                                isIconOnly
+                                size="sm"
+                                className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50"
+                                onPress={() => zoomIn()}
+                              >
+                                <ZoomIn className="w-4 h-4" />
+                              </Button>
+                              <span className="text-xs text-gray-600 ml-2">
+                                Scroll to zoom • Drag to pan • Double-click to reset
+                              </span>
+                            </div>
+
+                            {/* Image with Pan and Zoom */}
+                            <TransformComponent
+                              wrapperClass="!w-full !h-[60vh] bg-gray-100 rounded-lg"
+                              contentClass="!w-full !h-full flex items-center justify-center"
+                            >
+                              <div
+                                className="relative"
+                                style={{ width: "100%", height: "100%" }}
+                              >
+                                <Image
+                                  fill
+                                  unoptimized
+                                  alt={file.name}
+                                  className={`object-contain transition-opacity duration-300 ${loading ? "opacity-0" : "opacity-100"}`}
+                                  src={previewUrl}
+                                  onError={() => {
+                                    setLoading(false);
+                                    setError("Failed to load image");
+                                  }}
+                                  onLoad={() => setLoading(false)}
+                                />
+                              </div>
+                            </TransformComponent>
+                          </>
+                        )}
+                      </TransformWrapper>
                     </div>
                   )}
                   {error && (

--- a/app/(protected)/filebox/_components/FilePreview.tsx
+++ b/app/(protected)/filebox/_components/FilePreview.tsx
@@ -91,9 +91,11 @@ export function FilePreview({
     <Modal
       classNames={{
         base: "max-h-[85vh] bg-white",
-        body: "p-6",
+        body: "p-6 overflow-y-auto",
         header: "border-b border-gray-200",
         footer: "border-t border-gray-200",
+        wrapper: "z-[9999]",
+        backdrop: "z-[9998]",
       }}
       isOpen={isOpen}
       scrollBehavior="inside"
@@ -114,7 +116,7 @@ export function FilePreview({
               </div>
             </ModalHeader>
 
-            <ModalBody className="flex items-center justify-center bg-gray-50">
+            <ModalBody className="flex items-center justify-center bg-gray-50 pt-12">
               {isPDF ? (
                 <div className="w-full">
                   {error && (
@@ -144,15 +146,15 @@ export function FilePreview({
                         onLoadSuccess={onDocumentLoadSuccess}
                       >
                         <Page
-                          className="shadow-lg rounded-lg"
+                          className="shadow-lg rounded-lg mx-auto"
                           pageNumber={pageNumber}
                           renderAnnotationLayer={true}
                           renderTextLayer={true}
                           width={Math.min(
                             typeof window !== "undefined"
-                              ? window.innerWidth * 0.8
-                              : 800,
-                            800,
+                              ? window.innerWidth * 0.7
+                              : 700,
+                            700,
                           )}
                         />
                       </Document>
@@ -197,8 +199,8 @@ export function FilePreview({
                   )}
                   {!error && (
                     <div
-                      className="relative w-full max-w-4xl"
-                      style={{ height: "600px" }}
+                      className="relative w-full max-w-3xl"
+                      style={{ height: "500px" }}
                     >
                       <Image
                         fill

--- a/app/(protected)/filebox/_components/FilePreview.tsx
+++ b/app/(protected)/filebox/_components/FilePreview.tsx
@@ -11,7 +11,15 @@ import {
   Spinner,
 } from "@heroui/react";
 import { Document, Page, pdfjs } from "react-pdf";
-import { ChevronLeft, ChevronRight, Download, X, ZoomIn, ZoomOut, Maximize2 } from "lucide-react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Download,
+  X,
+  ZoomIn,
+  ZoomOut,
+  Maximize2,
+} from "lucide-react";
 import Image from "next/image";
 import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
 import { FileItem } from "./FileItem";
@@ -119,212 +127,213 @@ export function FilePreview({
 
             <ModalBody className="bg-gray-50 p-0">
               <div className="w-full min-h-full p-6">
-              {isPDF ? (
-                <div className="w-full">
-                  {error && (
-                    <div className="flex flex-col items-center justify-center py-12">
-                      <p className="text-red-600 mb-4">{error}</p>
-                      <Button
-                        className="bg-adult-green hover:bg-adult-green/90 text-white font-medium"
-                        onPress={onDownload}
-                      >
-                        <Download className="w-4 h-4 mr-2" />
-                        Download File
-                      </Button>
-                    </div>
-                  )}
-
-                  {!error && (
-                    <div className="flex flex-col items-center w-full">
-                      <Document
-                        file={previewUrl}
-                        loading={
-                          <div className="flex items-center justify-center py-12">
-                            <Spinner color="success" size="lg" />
-                          </div>
-                        }
-                        options={PDF_OPTIONS}
-                        onLoadError={onDocumentLoadError}
-                        onLoadSuccess={onDocumentLoadSuccess}
-                      >
-                        <Page
-                          className="shadow-lg rounded-lg mx-auto"
-                          pageNumber={pageNumber}
-                          renderAnnotationLayer={true}
-                          renderTextLayer={true}
-                          width={Math.min(
-                            typeof window !== "undefined"
-                              ? window.innerWidth * 0.7
-                              : 700,
-                            700,
-                          )}
-                        />
-                      </Document>
-
-                      {!loading && numPages > 0 && (
-                        <div className="flex items-center justify-center gap-4 mt-6 pb-4">
-                          <Button
-                            isIconOnly
-                            className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50"
-                            isDisabled={pageNumber <= 1}
-                            size="sm"
-                            onPress={goToPrevPage}
-                          >
-                            <ChevronLeft className="w-4 h-4" />
-                          </Button>
-                          <span className="text-sm text-gray-700 font-medium">
-                            Page {pageNumber} of {numPages}
-                          </span>
-                          <Button
-                            isIconOnly
-                            className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50"
-                            isDisabled={pageNumber >= numPages}
-                            size="sm"
-                            onPress={goToNextPage}
-                          >
-                            <ChevronRight className="w-4 h-4" />
-                          </Button>
-                        </div>
-                      )}
-                    </div>
-                  )}
-                </div>
-              ) : isImage ? (
-                <div
-                  key={previewUrl}
-                  className="w-full flex flex-col items-center"
-                >
-                  {loading && !error && (
-                    <div className="flex items-center justify-center py-12">
-                      <Spinner color="success" size="lg" />
-                    </div>
-                  )}
-                  {!error && (
-                    <div className="w-full">
-                      <TransformWrapper
-                        initialScale={1}
-                        minScale={0.5}
-                        maxScale={4}
-                        centerOnInit={true}
-                        wheel={{ step: 0.1 }}
-                        doubleClick={{ mode: "reset" }}
-                      >
-                        {({ zoomIn, zoomOut, resetTransform }) => (
-                          <>
-                            {/* Zoom Controls */}
-                            <div className="flex items-center justify-center gap-2 mb-4">
-                              <Button
-                                isIconOnly
-                                size="sm"
-                                className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50"
-                                onPress={() => zoomOut()}
-                              >
-                                <ZoomOut className="w-4 h-4" />
-                              </Button>
-                              <Button
-                                isIconOnly
-                                size="sm"
-                                className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50"
-                                onPress={() => resetTransform()}
-                              >
-                                <Maximize2 className="w-4 h-4" />
-                              </Button>
-                              <Button
-                                isIconOnly
-                                size="sm"
-                                className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50"
-                                onPress={() => zoomIn()}
-                              >
-                                <ZoomIn className="w-4 h-4" />
-                              </Button>
-                              <span className="text-xs text-gray-600 ml-2">
-                                Scroll to zoom • Drag to pan • Double-click to reset
-                              </span>
-                            </div>
-
-                            {/* Image with Pan and Zoom */}
-                            <TransformComponent
-                              wrapperClass="!w-full !h-[60vh] bg-gray-100 rounded-lg"
-                              contentClass="!w-full !h-full flex items-center justify-center"
-                            >
-                              <div
-                                className="relative"
-                                style={{ width: "100%", height: "100%" }}
-                              >
-                                <Image
-                                  fill
-                                  unoptimized
-                                  alt={file.name}
-                                  className={`object-contain transition-opacity duration-300 ${loading ? "opacity-0" : "opacity-100"}`}
-                                  src={previewUrl}
-                                  onError={() => {
-                                    setLoading(false);
-                                    setError("Failed to load image");
-                                  }}
-                                  onLoad={() => setLoading(false)}
-                                />
-                              </div>
-                            </TransformComponent>
-                          </>
-                        )}
-                      </TransformWrapper>
-                    </div>
-                  )}
-                  {error && (
-                    <div className="text-center">
-                      <p className="text-red-600 mb-4">{error}</p>
-                      <Button
-                        className="bg-adult-green hover:bg-adult-green/90 text-white font-medium"
-                        onPress={onDownload}
-                      >
-                        <Download className="w-4 h-4 mr-2" />
-                        Download File
-                      </Button>
-                    </div>
-                  )}
-                </div>
-              ) : isDocument ? (
-                <div className="w-full flex flex-col items-center justify-center py-12">
-                  <div className="text-center max-w-md">
-                    <div className="mb-6">
-                      <div className="w-20 h-20 mx-auto mb-4 bg-blue-100 rounded-full flex items-center justify-center">
-                        <Download className="w-10 h-10 text-blue-600" />
+                {isPDF ? (
+                  <div className="w-full">
+                    {error && (
+                      <div className="flex flex-col items-center justify-center py-12">
+                        <p className="text-red-600 mb-4">{error}</p>
+                        <Button
+                          className="bg-adult-green hover:bg-adult-green/90 text-white font-medium"
+                          onPress={onDownload}
+                        >
+                          <Download className="w-4 h-4 mr-2" />
+                          Download File
+                        </Button>
                       </div>
-                      <h4 className="text-lg font-semibold text-gray-900 mb-2">
-                        Document Preview Not Available
-                      </h4>
-                      <p className="text-gray-600 mb-6">
-                        Word documents (.doc, .docx) cannot be previewed in the
-                        browser. Download the file to view it in Microsoft Word
-                        or your preferred document editor.
-                      </p>
+                    )}
+
+                    {!error && (
+                      <div className="flex flex-col items-center w-full">
+                        <Document
+                          file={previewUrl}
+                          loading={
+                            <div className="flex items-center justify-center py-12">
+                              <Spinner color="success" size="lg" />
+                            </div>
+                          }
+                          options={PDF_OPTIONS}
+                          onLoadError={onDocumentLoadError}
+                          onLoadSuccess={onDocumentLoadSuccess}
+                        >
+                          <Page
+                            className="shadow-lg rounded-lg mx-auto"
+                            pageNumber={pageNumber}
+                            renderAnnotationLayer={true}
+                            renderTextLayer={true}
+                            width={Math.min(
+                              typeof window !== "undefined"
+                                ? window.innerWidth * 0.7
+                                : 700,
+                              700,
+                            )}
+                          />
+                        </Document>
+
+                        {!loading && numPages > 0 && (
+                          <div className="flex items-center justify-center gap-4 mt-6 pb-4">
+                            <Button
+                              isIconOnly
+                              className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50"
+                              isDisabled={pageNumber <= 1}
+                              size="sm"
+                              onPress={goToPrevPage}
+                            >
+                              <ChevronLeft className="w-4 h-4" />
+                            </Button>
+                            <span className="text-sm text-gray-700 font-medium">
+                              Page {pageNumber} of {numPages}
+                            </span>
+                            <Button
+                              isIconOnly
+                              className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50"
+                              isDisabled={pageNumber >= numPages}
+                              size="sm"
+                              onPress={goToNextPage}
+                            >
+                              <ChevronRight className="w-4 h-4" />
+                            </Button>
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                ) : isImage ? (
+                  <div
+                    key={previewUrl}
+                    className="w-full flex flex-col items-center"
+                  >
+                    {loading && !error && (
+                      <div className="flex items-center justify-center py-12">
+                        <Spinner color="success" size="lg" />
+                      </div>
+                    )}
+                    {!error && (
+                      <div className="w-full">
+                        <TransformWrapper
+                          centerOnInit={true}
+                          doubleClick={{ mode: "reset" }}
+                          initialScale={1}
+                          maxScale={4}
+                          minScale={0.5}
+                          wheel={{ step: 0.1 }}
+                        >
+                          {({ zoomIn, zoomOut, resetTransform }) => (
+                            <>
+                              {/* Zoom Controls */}
+                              <div className="flex items-center justify-center gap-2 mb-4">
+                                <Button
+                                  isIconOnly
+                                  className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50"
+                                  size="sm"
+                                  onPress={() => zoomOut()}
+                                >
+                                  <ZoomOut className="w-4 h-4" />
+                                </Button>
+                                <Button
+                                  isIconOnly
+                                  className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50"
+                                  size="sm"
+                                  onPress={() => resetTransform()}
+                                >
+                                  <Maximize2 className="w-4 h-4" />
+                                </Button>
+                                <Button
+                                  isIconOnly
+                                  className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50"
+                                  size="sm"
+                                  onPress={() => zoomIn()}
+                                >
+                                  <ZoomIn className="w-4 h-4" />
+                                </Button>
+                                <span className="text-xs text-gray-600 ml-2">
+                                  Scroll to zoom • Drag to pan • Double-click to
+                                  reset
+                                </span>
+                              </div>
+
+                              {/* Image with Pan and Zoom */}
+                              <TransformComponent
+                                contentClass="!w-full !h-full flex items-center justify-center"
+                                wrapperClass="!w-full !h-[60vh] bg-gray-100 rounded-lg"
+                              >
+                                <div
+                                  className="relative"
+                                  style={{ width: "100%", height: "100%" }}
+                                >
+                                  <Image
+                                    fill
+                                    unoptimized
+                                    alt={file.name}
+                                    className={`object-contain transition-opacity duration-300 ${loading ? "opacity-0" : "opacity-100"}`}
+                                    src={previewUrl}
+                                    onError={() => {
+                                      setLoading(false);
+                                      setError("Failed to load image");
+                                    }}
+                                    onLoad={() => setLoading(false)}
+                                  />
+                                </div>
+                              </TransformComponent>
+                            </>
+                          )}
+                        </TransformWrapper>
+                      </div>
+                    )}
+                    {error && (
+                      <div className="text-center">
+                        <p className="text-red-600 mb-4">{error}</p>
+                        <Button
+                          className="bg-adult-green hover:bg-adult-green/90 text-white font-medium"
+                          onPress={onDownload}
+                        >
+                          <Download className="w-4 h-4 mr-2" />
+                          Download File
+                        </Button>
+                      </div>
+                    )}
+                  </div>
+                ) : isDocument ? (
+                  <div className="w-full flex flex-col items-center justify-center py-12">
+                    <div className="text-center max-w-md">
+                      <div className="mb-6">
+                        <div className="w-20 h-20 mx-auto mb-4 bg-blue-100 rounded-full flex items-center justify-center">
+                          <Download className="w-10 h-10 text-blue-600" />
+                        </div>
+                        <h4 className="text-lg font-semibold text-gray-900 mb-2">
+                          Document Preview Not Available
+                        </h4>
+                        <p className="text-gray-600 mb-6">
+                          Word documents (.doc, .docx) cannot be previewed in
+                          the browser. Download the file to view it in Microsoft
+                          Word or your preferred document editor.
+                        </p>
+                      </div>
+                      <Button
+                        className="bg-adult-green hover:bg-adult-green/90 text-white font-medium"
+                        size="lg"
+                        onPress={onDownload}
+                      >
+                        <Download className="w-5 h-5 mr-2" />
+                        Download Document
+                      </Button>
                     </div>
-                    <Button
-                      className="bg-adult-green hover:bg-adult-green/90 text-white font-medium"
-                      size="lg"
-                      onPress={onDownload}
-                    >
-                      <Download className="w-5 h-5 mr-2" />
-                      Download Document
-                    </Button>
                   </div>
-                </div>
-              ) : (
-                <div className="w-full flex flex-col items-center justify-center py-12">
-                  <div className="text-center">
-                    <p className="text-gray-600 mb-4">
-                      Preview not available for this file type.
-                    </p>
-                    <Button
-                      className="bg-adult-green hover:bg-adult-green/90 text-white font-medium"
-                      onPress={onDownload}
-                    >
-                      <Download className="w-4 h-4 mr-2" />
-                      Download File
-                    </Button>
+                ) : (
+                  <div className="w-full flex flex-col items-center justify-center py-12">
+                    <div className="text-center">
+                      <p className="text-gray-600 mb-4">
+                        Preview not available for this file type.
+                      </p>
+                      <Button
+                        className="bg-adult-green hover:bg-adult-green/90 text-white font-medium"
+                        onPress={onDownload}
+                      >
+                        <Download className="w-4 h-4 mr-2" />
+                        Download File
+                      </Button>
+                    </div>
                   </div>
-                </div>
-              )}
+                )}
               </div>
             </ModalBody>
 

--- a/app/(protected)/filebox/_components/SecureDocument.tsx
+++ b/app/(protected)/filebox/_components/SecureDocument.tsx
@@ -33,11 +33,11 @@ export function SecureDocument({
 }: SecureDocumentProps) {
   // Initialize secure storage hook
   const { getSecureItem, setSecureItem, removeSecureItem } = useSecureStorage();
-  
+
   // Memoize the storage key for this file+action combination
   const cooldownKey = useMemo(
     () => `otp_cooldown_${file.id}_${action}`,
-    [file.id, action]
+    [file.id, action],
   );
 
   // Initialize state with lazy function (like OnboardingModal)
@@ -45,13 +45,15 @@ export function SecureDocument({
   const [focusedIndex, setFocusedIndex] = useState(0);
   const [errorMessage, setErrorMessage] = useState("");
   const [successMessage, setSuccessMessage] = useState("");
-  
+
   const [otpSent, setOtpSent] = useState<boolean>(() => {
     const stored = getSecureItem(cooldownKey);
+
     if (!stored) return false;
 
     try {
       const expiryTime = parseInt(stored, 10);
+
       return Date.now() < expiryTime;
     } catch {
       return false;
@@ -60,6 +62,7 @@ export function SecureDocument({
 
   const [cooldown, setCooldown] = useState<number>(() => {
     const stored = getSecureItem(cooldownKey);
+
     if (!stored) return 0;
 
     try {
@@ -69,6 +72,7 @@ export function SecureDocument({
       if (expiryTime <= now) {
         removeSecureItem(cooldownKey);
         sessionStorage.removeItem(`otpTimer:${file.id}`);
+
         return 0;
       }
 
@@ -76,6 +80,7 @@ export function SecureDocument({
     } catch {
       removeSecureItem(cooldownKey);
       sessionStorage.removeItem(`otpTimer:${file.id}`);
+
       return 0;
     }
   });
@@ -163,11 +168,16 @@ export function SecureDocument({
             setErrorMessage("");
             setOtpSent(true);
             setCooldown(COOLDOWN_SECONDS);
-            
+
             // Store cooldown expiry timestamp in secure storage
             const expiryTime = Date.now() + COOLDOWN_SECONDS * 1000;
-            setSecureItem(cooldownKey, expiryTime.toString(), COOLDOWN_SECONDS / 60);
-            
+
+            setSecureItem(
+              cooldownKey,
+              expiryTime.toString(),
+              COOLDOWN_SECONDS / 60,
+            );
+
             resolve(COOLDOWN_SECONDS);
           },
           onError: (error: any) => {
@@ -221,7 +231,6 @@ export function SecureDocument({
           // Clear cooldown on successful verification
           removeSecureItem(cooldownKey);
 
-                    
           // Also clear ResendTimer's sessionStorage
           sessionStorage.removeItem(`otpTimer:${file.id}`);
 

--- a/app/(protected)/filebox/page.tsx
+++ b/app/(protected)/filebox/page.tsx
@@ -1,4 +1,3 @@
-import ProtectedPageWrapper from "@/components/ui/ProtectedPageWrapper";
 import { FileBox } from "./_components/FileBox";
 
 export default function FileBoxPage() {

--- a/app/(protected)/filebox/page.tsx
+++ b/app/(protected)/filebox/page.tsx
@@ -3,22 +3,18 @@ import { FileBox } from "./_components/FileBox";
 
 export default function FileBoxPage() {
   return (
-    <div>
-      <ProtectedPageWrapper>
-        <div className="flex h-screen flex-col">
-          {/* Header */}
-          <header className="border-b border-gray-200 bg-white px-6 py-4 dark:border-gray-700 dark:bg-gray-900">
-            <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
-              Adulting Filebox
-            </h1>
-          </header>
+    <div className="flex h-screen flex-col">
+      {/* Header */}
+      <header className="border-b border-gray-200 bg-white px-6 py-4 dark:border-gray-700 dark:bg-gray-900">
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+          Adulting Filebox
+        </h1>
+      </header>
 
-          {/* FileBox Container */}
-          <main className="flex-1 overflow-hidden">
-            <FileBox />
-          </main>
-        </div>
-      </ProtectedPageWrapper>
+      {/* FileBox Container */}
+      <main className="flex-1 overflow-hidden">
+        <FileBox />
+      </main>
     </div>
   );
 }

--- a/components/ui/theme-switch.tsx
+++ b/components/ui/theme-switch.tsx
@@ -25,17 +25,12 @@ export const ThemeSwitch: FC<ThemeSwitchProps> = ({
     theme === "light" ? setTheme("dark") : setTheme("light");
   };
 
-  const {
-    slots,
-    isSelected,
-    getBaseProps,
-    getInputProps,
-    getWrapperProps,
-  } = useSwitch({
-    isSelected: theme === "light" || isSSR,
-    "aria-label": `Switch to ${theme === "light" || isSSR ? "dark" : "light"} mode`,
-    onChange,
-  });
+  const { slots, isSelected, getBaseProps, getInputProps, getWrapperProps } =
+    useSwitch({
+      isSelected: theme === "light" || isSSR,
+      "aria-label": `Switch to ${theme === "light" || isSSR ? "dark" : "light"} mode`,
+      onChange,
+    });
 
   return (
     <div

--- a/components/ui/theme-switch.tsx
+++ b/components/ui/theme-switch.tsx
@@ -26,7 +26,6 @@ export const ThemeSwitch: FC<ThemeSwitchProps> = ({
   };
 
   const {
-    Component,
     slots,
     isSelected,
     getBaseProps,

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react-google-recaptcha": "^3.1.0",
     "react-hook-form": "^7.62.0",
     "react-pdf": "^10.2.0",
+    "react-zoom-pan-pinch": "^3.7.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
     "three": "^0.180.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       react-pdf:
         specifier: ^10.2.0
         version: 10.2.0(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-zoom-pan-pinch:
+        specifier: ^3.7.0
+        version: 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -5503,6 +5506,13 @@ packages:
     peerDependenciesMeta:
       react-dom:
         optional: true
+
+  react-zoom-pan-pinch@3.7.0:
+    resolution: {integrity: sha512-UmReVZ0TxlKzxSbYiAj+LeGRW8s8LraAFTXRAxzMYnNRgGPsxCudwZKVkjvGmjtx7SW/hZamt69NUmGf4xrkXA==}
+    engines: {node: '>=8', npm: '>=5'}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
 
   react@17.0.2:
     resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}
@@ -13368,6 +13378,11 @@ snapshots:
     dependencies:
       react: 18.3.1
     optionalDependencies:
+      react-dom: 18.3.1(react@18.3.1)
+
+  react-zoom-pan-pinch@3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
   react@17.0.2:


### PR DESCRIPTION
# 🚀 Pull Request Template

## 📋 Summary

Fixed the double side bar issue 
Fixed the filebox preview
Fixed the issue with the cropped PDF
Fixed the rendering of the image to pinch and zoom
Added the OTPtimer to the sessionStorage

## 🔧 Changes

<!-- List the key changes made in this PR. -->

Fixed the double side bar issue 
Fixed the filebox preview
Fixed the issue with the cropped PDF
Fixed the rendering of the image to pinch and zoom
Added the OTPtimer to the sessionStorage


## 🔗 Related Issue


Closes #82-hotfix/filebox-preview-conflict-with-sidebar-menu

## Notes for Reviewers

<!-- Include any additional notes or context for the reviewers. -->
