### PR TITLE
119-hotfix/otp-states

### DIFF
--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -2,7 +2,9 @@
 
 import { ProtectedRoute } from "@/components/RouteGuards";
 import UserSidebar from "@/components/ui/sidebar/UserSidebar";
+import { IdleWarningModal } from "@/components/ui/IdleWarningModal";
 import { usePathname } from "next/navigation";
+import { useAuth } from "@/hooks/queries/useAuthQueries";
 
 interface ProtectedLayoutProps {
   children: React.ReactNode;
@@ -11,6 +13,7 @@ interface ProtectedLayoutProps {
 export default function ProtectedLayout({ children }: ProtectedLayoutProps) {
   const pathname = usePathname();
   const isAIGabayPage = pathname.startsWith("/ai-gabay");
+  const { showIdleWarning, onStayActive, onLogoutNow } = useAuth();
 
   return (
     <ProtectedRoute roles={["user"]}>
@@ -19,6 +22,11 @@ export default function ProtectedLayout({ children }: ProtectedLayoutProps) {
       ) : (
         <UserSidebar>{children}</UserSidebar>
       )}
+      <IdleWarningModal
+        open={showIdleWarning}
+        onStayActive={onStayActive}
+        onLogout={onLogoutNow}
+      />
     </ProtectedRoute>
   );
 }

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -24,8 +24,8 @@ export default function ProtectedLayout({ children }: ProtectedLayoutProps) {
       )}
       <IdleWarningModal
         open={showIdleWarning}
-        onStayActive={onStayActive}
         onLogout={onLogoutNow}
+        onStayActive={onStayActive}
       />
     </ProtectedRoute>
   );

--- a/app/auth/forgot-password/_components/ForgotPasswordForm.tsx
+++ b/app/auth/forgot-password/_components/ForgotPasswordForm.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { useState, useRef } from "react";
-import { useSecureStorageListener } from "@/hooks/useSecureStorage";
+import {
+  useSecureStorageListener,
+  useSecureStorage,
+} from "@/hooks/useSecureStorage";
 import EmailStep from "./InputEmail";
 import OtpStep from "./InputOtp";
 import ResetPasswordStep from "./ResetPassword";
@@ -9,11 +12,21 @@ import { UserAuthTitle } from "../../register/_components/UserAuthTitle";
 import { ImageContainer } from "../../register/_components/ImageContainer";
 
 const BackToLoginButton = () => {
+  const { removeSecureItem } = useSecureStorage();
+
+  const handleBackToLogin = () => {
+    // Clear forgot password flow data when returning to login
+    removeSecureItem("forgotPasswordEmail");
+    removeSecureItem("forgotPasswordStep");
+    removeSecureItem("forgotPasswordToken");
+  };
+
   return (
     <div className="mb-6">
       <a
         className="inline-flex items-center gap-2 text-sm text-gray-600 hover:text-gray-800 transition-colors"
         href="/auth/login"
+        onClick={handleBackToLogin}
       >
         <svg
           className="w-4 h-4"
@@ -100,8 +113,8 @@ export default function ForgotPassword() {
       {/* Left Side - Forgot Password Form */}
       <div className="flex-1 lg:w-1/2 flex items-center justify-center p-8 bg-white">
         <div className="w-full max-w-md">
-          {/* Back to Login - Show on email and reset steps */}
-          {(step === "email" || step === "reset") && <BackToLoginButton />}
+          {/* Back to Login - Show on all steps */}
+          <BackToLoginButton />
 
           {/* Title and Subtitle */}
           {step === "otp" ? (

--- a/app/auth/login/_components/LoginForm.tsx
+++ b/app/auth/login/_components/LoginForm.tsx
@@ -8,10 +8,19 @@ import { GoogleSignInButton } from "../../register/_components/GoogleSignInButto
 import { ImageContainer } from "../../register/_components/ImageContainer";
 import { useLogin } from "../hooks/useLogin";
 import { useGoogleAuth } from "../../../../hooks/useGoogleAuth";
+import { useSecureStorage } from "@/hooks/useSecureStorage";
 
 export const LoginForm = () => {
   const { register, errors, loading, onSubmit } = useLogin();
   const { handleGoogleSignIn } = useGoogleAuth();
+  const { removeSecureItem } = useSecureStorage();
+
+  const handleForgotPasswordClick = () => {
+    // Clear forgot password flow data to start fresh
+    removeSecureItem("forgotPasswordEmail");
+    removeSecureItem("forgotPasswordStep");
+    removeSecureItem("forgotPasswordToken");
+  };
 
   return (
     <div className="min-h-screen flex">
@@ -47,6 +56,7 @@ export const LoginForm = () => {
               <Link
                 className="text-sm text-green-700 hover:text-green-800 font-medium"
                 href="/auth/forgot-password"
+                onClick={handleForgotPasswordClick}
               >
                 Forgot Password?
               </Link>

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,6 +1,30 @@
 import React from "react";
 import clsx from "clsx";
 
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  children: React.ReactNode;
+}
+
+export const Button = ({
+  children,
+  className,
+  type = "button",
+  ...rest
+}: ButtonProps) => {
+  return (
+    <button
+      className={clsx(
+        "px-4 py-2 rounded text-white disabled:opacity-60",
+        className,
+      )}
+      type={type}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+};
+
 interface LoadingButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   loading?: boolean;

--- a/components/ui/IdleWarningModal.tsx
+++ b/components/ui/IdleWarningModal.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { Modal } from "./Modal";
+import { Button } from "./Button";
+
+interface IdleWarningModalProps {
+  open: boolean;
+  onStayActive: () => void;
+  onLogout: () => void;
+  countdownSeconds?: number;
+}
+
+export const IdleWarningModal = ({
+  open,
+  onStayActive,
+  onLogout,
+  countdownSeconds = 120, // 2 minutes default
+}: IdleWarningModalProps) => {
+  const [timeLeft, setTimeLeft] = useState(countdownSeconds);
+
+  useEffect(() => {
+    if (!open) {
+      setTimeLeft(countdownSeconds);
+      return;
+    }
+
+    const interval = setInterval(() => {
+      setTimeLeft((prev) => {
+        if (prev <= 1) {
+          clearInterval(interval);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [open, countdownSeconds]);
+
+  const formatTime = (seconds: number) => {
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${mins}:${secs.toString().padStart(2, "0")}`;
+  };
+
+  return (
+    <Modal open={open} onClose={onStayActive} title="Are you still there?" size="sm">
+      <div className="space-y-4">
+        <p className="text-gray-600 dark:text-gray-300">
+          You've been inactive for a while. For your security, you will be automatically
+          logged out in:
+        </p>
+
+        <div className="flex justify-center">
+          <div className="bg-red-50 dark:bg-red-900/20 border-2 border-red-500 rounded-lg px-6 py-4">
+            <div className="text-4xl font-bold text-red-600 dark:text-red-400 text-center tabular-nums">
+              {formatTime(timeLeft)}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex gap-3 pt-4">
+          <Button
+            onClick={onStayActive}
+            className="flex-1 bg-primary-600 hover:bg-primary-700 text-white"
+          >
+            Stay Logged In
+          </Button>
+          <Button
+            onClick={onLogout}
+            className="flex-1 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-800 dark:text-gray-200"
+          >
+            Logout Now
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};

--- a/components/ui/IdleWarningModal.tsx
+++ b/components/ui/IdleWarningModal.tsx
@@ -22,6 +22,7 @@ export const IdleWarningModal = ({
   useEffect(() => {
     if (!open) {
       setTimeLeft(countdownSeconds);
+
       return;
     }
 
@@ -29,8 +30,10 @@ export const IdleWarningModal = ({
       setTimeLeft((prev) => {
         if (prev <= 1) {
           clearInterval(interval);
+
           return 0;
         }
+
         return prev - 1;
       });
     }, 1000);
@@ -41,15 +44,21 @@ export const IdleWarningModal = ({
   const formatTime = (seconds: number) => {
     const mins = Math.floor(seconds / 60);
     const secs = seconds % 60;
+
     return `${mins}:${secs.toString().padStart(2, "0")}`;
   };
 
   return (
-    <Modal open={open} onClose={onStayActive} title="Are you still there?" size="sm">
+    <Modal
+      open={open}
+      size="sm"
+      title="Are you still there?"
+      onClose={onStayActive}
+    >
       <div className="space-y-4">
         <p className="text-gray-600 dark:text-gray-300">
-          You've been inactive for a while. For your security, you will be automatically
-          logged out in:
+          You&apos;ve been inactive for a while. For your security, you will be
+          automatically logged out in:
         </p>
 
         <div className="flex justify-center">
@@ -62,14 +71,14 @@ export const IdleWarningModal = ({
 
         <div className="flex gap-3 pt-4">
           <Button
+            className="flex-1 bg-adult-green hover:bg-adult-green/90 text-white"
             onClick={onStayActive}
-            className="flex-1 bg-primary-600 hover:bg-primary-700 text-white"
           >
             Stay Logged In
           </Button>
           <Button
-            onClick={onLogout}
             className="flex-1 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-800 dark:text-gray-200"
+            onClick={onLogout}
           >
             Logout Now
           </Button>

--- a/hooks/useIdleTimeout.ts
+++ b/hooks/useIdleTimeout.ts
@@ -23,7 +23,7 @@ interface UseIdleTimeoutOptions {
 
 export function useIdleTimeout(
   onIdle: (() => void) | UseIdleTimeoutOptions,
-  enabled: boolean = true
+  enabled: boolean = true,
 ) {
   // Support both old and new API
   const options: UseIdleTimeoutOptions =
@@ -31,8 +31,13 @@ export function useIdleTimeout(
       ? { onIdle, enabled }
       : { ...onIdle, enabled: onIdle.enabled ?? true };
 
-  const { onIdle: idleCallback, onWarning, warningTime = WARNING_BEFORE_TIMEOUT } = options;
-  const isEnabled = typeof onIdle === "function" ? enabled : options.enabled ?? true;
+  const {
+    onIdle: idleCallback,
+    onWarning,
+    warningTime = WARNING_BEFORE_TIMEOUT,
+  } = options;
+  const isEnabled =
+    typeof onIdle === "function" ? enabled : (options.enabled ?? true);
 
   const idleTimerRef = useRef<NodeJS.Timeout | null>(null);
   const warningTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -84,6 +89,7 @@ export function useIdleTimeout(
   useEffect(() => {
     if (!isEnabled) {
       clearAllTimers();
+
       return;
     }
 


### PR DESCRIPTION
# 🚀 Pull Request Template

## 📋 Summary

Fixed the issue where the user is getting shown the otpInput even after the token expires and the user exits the otp  input page

## 🔧 Changes

-Cleared the secure storage/states when exiting the otp input and when clicking on the forgot password
-Added a cooldown modal for the idle Timer

## 🔗 Related Issue

Closes #119 hotfix/otp-states

## Notes for Reviewers

<!-- Include any additional notes or context for the reviewers. -->
